### PR TITLE
Implement fallback outbound

### DIFF
--- a/constant/proxy.go
+++ b/constant/proxy.go
@@ -33,6 +33,7 @@ const (
 const (
 	TypeSelector = "selector"
 	TypeURLTest  = "urltest"
+	TypeFallback = "fallback"
 )
 
 func ProxyDisplayName(proxyType string) string {
@@ -87,6 +88,8 @@ func ProxyDisplayName(proxyType string) string {
 		return "Selector"
 	case TypeURLTest:
 		return "URLTest"
+	case TypeFallback:
+		return "Fallback"
 	default:
 		return "Unknown"
 	}

--- a/docs/configuration/outbound/fallback.md
+++ b/docs/configuration/outbound/fallback.md
@@ -1,0 +1,43 @@
+### Structure
+
+```json
+{
+  "type": "fallback",
+  "tag": "fb",
+
+  "outbounds": [
+    "primary",
+    "backup"
+  ],
+  "url": "",
+  "interval": "",
+  "idle_timeout": "",
+  "interrupt_exist_connections": false
+}
+```
+
+### Fields
+
+#### outbounds
+
+==Required==
+
+Outbound tags in priority order.
+
+#### url
+
+URL used for connectivity check. `https://www.gstatic.com/generate_204` will be used if empty.
+
+#### interval
+
+Check interval. `3m` will be used if empty.
+
+#### idle_timeout
+
+Idle timeout. `30m` will be used if empty.
+
+#### interrupt_exist_connections
+
+Interrupt existing connections when selected outbound changes.
+
+Only inbound connections are affected; internal connections are always interrupted.

--- a/docs/configuration/outbound/fallback.zh.md
+++ b/docs/configuration/outbound/fallback.zh.md
@@ -1,0 +1,43 @@
+### 结构
+
+```json
+{
+  "type": "fallback",
+  "tag": "fb",
+
+  "outbounds": [
+    "primary",
+    "backup"
+  ],
+  "url": "",
+  "interval": "",
+  "idle_timeout": "",
+  "interrupt_exist_connections": false
+}
+```
+
+### 字段
+
+#### outbounds
+
+==必填==
+
+按优先级排列的出站标签列表。
+
+#### url
+
+用于检查连接的链接。默认使用 `https://www.gstatic.com/generate_204`。
+
+#### interval
+
+检查间隔。默认使用 `3m`。
+
+#### idle_timeout
+
+空闲超时。默认使用 `30m`。
+
+#### interrupt_exist_connections
+
+当选定的出站发生改变时，中断现有连接。
+
+仅入站连接受此设置影响，内部连接将始终被中断。

--- a/docs/configuration/outbound/index.md
+++ b/docs/configuration/outbound/index.md
@@ -36,6 +36,7 @@
 | `dns`          | [DNS](./dns/)                   |
 | `selector`     | [Selector](./selector/)         |
 | `urltest`      | [URLTest](./urltest/)           |
+| `fallback`     | [Fallback](./fallback/)         |
 
 #### tag
 

--- a/docs/configuration/outbound/index.zh.md
+++ b/docs/configuration/outbound/index.zh.md
@@ -36,6 +36,7 @@
 | `dns`          | [DNS](./dns/)                   |
 | `selector`     | [Selector](./selector/)         |
 | `urltest`      | [URLTest](./urltest/)           |
+| `fallback`     | [Fallback](./fallback/)         |
 
 #### tag
 

--- a/include/registry.go
+++ b/include/registry.go
@@ -80,6 +80,7 @@ func OutboundRegistry() *outbound.Registry {
 
 	group.RegisterSelector(registry)
 	group.RegisterURLTest(registry)
+	group.RegisterFallback(registry)
 
 	socks.RegisterOutbound(registry)
 	http.RegisterOutbound(registry)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
           - DNS: configuration/outbound/dns.md
           - Selector: configuration/outbound/selector.md
           - URLTest: configuration/outbound/urltest.md
+          - Fallback: configuration/outbound/fallback.md
       - Service:
           - configuration/service/index.md
           - DERP: configuration/service/derp.md

--- a/option/group.go
+++ b/option/group.go
@@ -16,3 +16,11 @@ type URLTestOutboundOptions struct {
 	IdleTimeout               badoption.Duration `json:"idle_timeout,omitempty"`
 	InterruptExistConnections bool               `json:"interrupt_exist_connections,omitempty"`
 }
+
+type FallbackOutboundOptions struct {
+	Outbounds                 []string           `json:"outbounds"`
+	URL                       string             `json:"url,omitempty"`
+	Interval                  badoption.Duration `json:"interval,omitempty"`
+	IdleTimeout               badoption.Duration `json:"idle_timeout,omitempty"`
+	InterruptExistConnections bool               `json:"interrupt_exist_connections,omitempty"`
+}

--- a/protocol/group/fallback.go
+++ b/protocol/group/fallback.go
@@ -1,0 +1,370 @@
+package group
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/outbound"
+	"github.com/sagernet/sing-box/common/interrupt"
+	"github.com/sagernet/sing-box/common/urltest"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/atomic"
+	"github.com/sagernet/sing/common/batch"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/x/list"
+	"github.com/sagernet/sing/service"
+	"github.com/sagernet/sing/service/pause"
+)
+
+func RegisterFallback(registry *outbound.Registry) {
+	outbound.Register[option.FallbackOutboundOptions](registry, C.TypeFallback, NewFallback)
+}
+
+var _ adapter.OutboundGroup = (*Fallback)(nil)
+
+type Fallback struct {
+	outbound.Adapter
+	ctx                          context.Context
+	router                       adapter.Router
+	outbound                     adapter.OutboundManager
+	connection                   adapter.ConnectionManager
+	logger                       log.ContextLogger
+	tags                         []string
+	link                         string
+	interval                     time.Duration
+	idleTimeout                  time.Duration
+	group                        *FallbackGroup
+	interruptExternalConnections bool
+}
+
+func NewFallback(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.FallbackOutboundOptions) (adapter.Outbound, error) {
+	outbound := &Fallback{
+		Adapter:                      outbound.NewAdapter(C.TypeFallback, tag, []string{N.NetworkTCP, N.NetworkUDP}, options.Outbounds),
+		ctx:                          ctx,
+		router:                       router,
+		outbound:                     service.FromContext[adapter.OutboundManager](ctx),
+		connection:                   service.FromContext[adapter.ConnectionManager](ctx),
+		logger:                       logger,
+		tags:                         options.Outbounds,
+		link:                         options.URL,
+		interval:                     time.Duration(options.Interval),
+		idleTimeout:                  time.Duration(options.IdleTimeout),
+		interruptExternalConnections: options.InterruptExistConnections,
+	}
+	if len(outbound.tags) == 0 {
+		return nil, E.New("missing tags")
+	}
+	return outbound, nil
+}
+
+func (s *Fallback) Start() error {
+	outbounds := make([]adapter.Outbound, 0, len(s.tags))
+	for i, tag := range s.tags {
+		detour, loaded := s.outbound.Outbound(tag)
+		if !loaded {
+			return E.New("outbound ", i, " not found: ", tag)
+		}
+		outbounds = append(outbounds, detour)
+	}
+	group, err := NewFallbackGroup(s.ctx, s.outbound, s.logger, outbounds, s.link, s.interval, s.idleTimeout, s.interruptExternalConnections)
+	if err != nil {
+		return err
+	}
+	s.group = group
+	return nil
+}
+
+func (s *Fallback) PostStart() error {
+	s.group.PostStart()
+	return nil
+}
+
+func (s *Fallback) Close() error {
+	return common.Close(
+		common.PtrOrNil(s.group),
+	)
+}
+
+func (s *Fallback) Now() string {
+	if s.group.selectedOutboundTCP != nil {
+		return s.group.selectedOutboundTCP.Tag()
+	} else if s.group.selectedOutboundUDP != nil {
+		return s.group.selectedOutboundUDP.Tag()
+	}
+	return ""
+}
+
+func (s *Fallback) All() []string { return s.tags }
+
+func (s *Fallback) CheckOutbounds() { s.group.CheckOutbounds(true) }
+
+func (s *Fallback) DialContext(ctx context.Context, network string, destination M.Socksaddr) (net.Conn, error) {
+	s.group.Touch()
+	var ob adapter.Outbound
+	switch N.NetworkName(network) {
+	case N.NetworkTCP:
+		ob = s.group.selectedOutboundTCP
+	case N.NetworkUDP:
+		ob = s.group.selectedOutboundUDP
+	default:
+		return nil, E.Extend(N.ErrUnknownNetwork, network)
+	}
+	if ob == nil {
+		ob, _ = s.group.Select(network)
+	}
+	if ob == nil {
+		return nil, E.New("missing supported outbound")
+	}
+	conn, err := ob.DialContext(ctx, network, destination)
+	if err == nil {
+		return s.group.interruptGroup.NewConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+	}
+	s.logger.ErrorContext(ctx, err)
+	s.group.history.DeleteURLTestHistory(ob.Tag())
+	return nil, err
+}
+
+func (s *Fallback) ListenPacket(ctx context.Context, destination M.Socksaddr) (net.PacketConn, error) {
+	s.group.Touch()
+	ob := s.group.selectedOutboundUDP
+	if ob == nil {
+		ob, _ = s.group.Select(N.NetworkUDP)
+	}
+	if ob == nil {
+		return nil, E.New("missing supported outbound")
+	}
+	conn, err := ob.ListenPacket(ctx, destination)
+	if err == nil {
+		return s.group.interruptGroup.NewPacketConn(conn, interrupt.IsExternalConnectionFromContext(ctx)), nil
+	}
+	s.logger.ErrorContext(ctx, err)
+	s.group.history.DeleteURLTestHistory(ob.Tag())
+	return nil, err
+}
+
+func (s *Fallback) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	ctx = interrupt.ContextWithIsExternalConnection(ctx)
+	s.connection.NewConnection(ctx, s, conn, metadata, onClose)
+}
+
+func (s *Fallback) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	ctx = interrupt.ContextWithIsExternalConnection(ctx)
+	s.connection.NewPacketConnection(ctx, s, conn, metadata, onClose)
+}
+
+// Group implementation
+
+type FallbackGroup struct {
+	ctx                          context.Context
+	outbound                     adapter.OutboundManager
+	pause                        pause.Manager
+	pauseCallback                *list.Element[pause.Callback]
+	logger                       log.Logger
+	outbounds                    []adapter.Outbound
+	link                         string
+	interval                     time.Duration
+	idleTimeout                  time.Duration
+	history                      adapter.URLTestHistoryStorage
+	checking                     atomic.Bool
+	selectedOutboundTCP          adapter.Outbound
+	selectedOutboundUDP          adapter.Outbound
+	interruptGroup               *interrupt.Group
+	interruptExternalConnections bool
+	access                       sync.Mutex
+	ticker                       *time.Ticker
+	close                        chan struct{}
+	started                      bool
+	lastActive                   atomic.TypedValue[time.Time]
+}
+
+func NewFallbackGroup(ctx context.Context, outboundManager adapter.OutboundManager, logger log.Logger, outbounds []adapter.Outbound, link string, interval time.Duration, idleTimeout time.Duration, interruptExternalConnections bool) (*FallbackGroup, error) {
+	if interval == 0 {
+		interval = C.DefaultURLTestInterval
+	}
+	if idleTimeout == 0 {
+		idleTimeout = C.DefaultURLTestIdleTimeout
+	}
+	if interval > idleTimeout {
+		return nil, E.New("interval must be less or equal than idle_timeout")
+	}
+	var history adapter.URLTestHistoryStorage
+	if historyFromCtx := service.PtrFromContext[urltest.HistoryStorage](ctx); historyFromCtx != nil {
+		history = historyFromCtx
+	} else if clashServer := service.FromContext[adapter.ClashServer](ctx); clashServer != nil {
+		history = clashServer.HistoryStorage()
+	} else {
+		history = urltest.NewHistoryStorage()
+	}
+	return &FallbackGroup{
+		ctx:                          ctx,
+		outbound:                     outboundManager,
+		logger:                       logger,
+		outbounds:                    outbounds,
+		link:                         link,
+		interval:                     interval,
+		idleTimeout:                  idleTimeout,
+		history:                      history,
+		close:                        make(chan struct{}),
+		pause:                        service.FromContext[pause.Manager](ctx),
+		interruptGroup:               interrupt.NewGroup(),
+		interruptExternalConnections: interruptExternalConnections,
+	}, nil
+}
+
+func (g *FallbackGroup) PostStart() {
+	g.access.Lock()
+	defer g.access.Unlock()
+	g.started = true
+	g.lastActive.Store(time.Now())
+	go g.CheckOutbounds(false)
+}
+
+func (g *FallbackGroup) Touch() {
+	if !g.started {
+		return
+	}
+	g.access.Lock()
+	defer g.access.Unlock()
+	if g.ticker != nil {
+		g.lastActive.Store(time.Now())
+		return
+	}
+	g.ticker = time.NewTicker(g.interval)
+	go g.loopCheck()
+	g.pauseCallback = pause.RegisterTicker(g.pause, g.ticker, g.interval, nil)
+}
+
+func (g *FallbackGroup) Close() error {
+	g.access.Lock()
+	defer g.access.Unlock()
+	if g.ticker == nil {
+		return nil
+	}
+	g.ticker.Stop()
+	g.pause.UnregisterCallback(g.pauseCallback)
+	close(g.close)
+	return nil
+}
+
+func (g *FallbackGroup) Select(network string) (adapter.Outbound, bool) {
+	// first available outbound with history
+	for _, detour := range g.outbounds {
+		if !common.Contains(detour.Network(), network) {
+			continue
+		}
+		if g.history.LoadURLTestHistory(RealTag(detour)) != nil {
+			return detour, true
+		}
+	}
+	for _, detour := range g.outbounds {
+		if common.Contains(detour.Network(), network) {
+			return detour, false
+		}
+	}
+	return nil, false
+}
+
+func (g *FallbackGroup) loopCheck() {
+	if time.Since(g.lastActive.Load()) > g.interval {
+		g.lastActive.Store(time.Now())
+		g.CheckOutbounds(false)
+	}
+	for {
+		select {
+		case <-g.close:
+			return
+		case <-g.ticker.C:
+		}
+		if time.Since(g.lastActive.Load()) > g.idleTimeout {
+			g.access.Lock()
+			g.ticker.Stop()
+			g.ticker = nil
+			g.pause.UnregisterCallback(g.pauseCallback)
+			g.pauseCallback = nil
+			g.access.Unlock()
+			return
+		}
+		g.CheckOutbounds(false)
+	}
+}
+
+func (g *FallbackGroup) CheckOutbounds(force bool) {
+	_, _ = g.urlTest(g.ctx, force)
+}
+
+func (g *FallbackGroup) URLTest(ctx context.Context) (map[string]uint16, error) {
+	return g.urlTest(ctx, false)
+}
+
+func (g *FallbackGroup) urlTest(ctx context.Context, force bool) (map[string]uint16, error) {
+	result := make(map[string]uint16)
+	if g.checking.Swap(true) {
+		return result, nil
+	}
+	defer g.checking.Store(false)
+	b, _ := batch.New(ctx, batch.WithConcurrencyNum[any](10))
+	checked := make(map[string]bool)
+	var resultAccess sync.Mutex
+	for _, detour := range g.outbounds {
+		tag := detour.Tag()
+		realTag := RealTag(detour)
+		if checked[realTag] {
+			continue
+		}
+		history := g.history.LoadURLTestHistory(realTag)
+		if !force && history != nil && time.Since(history.Time) < g.interval {
+			continue
+		}
+		checked[realTag] = true
+		p, loaded := g.outbound.Outbound(realTag)
+		if !loaded {
+			continue
+		}
+		b.Go(realTag, func() (any, error) {
+			testCtx, cancel := context.WithTimeout(g.ctx, C.TCPTimeout)
+			defer cancel()
+			t, err := urltest.URLTest(testCtx, g.link, p)
+			if err != nil {
+				g.logger.Debug("outbound ", tag, " unavailable: ", err)
+				g.history.DeleteURLTestHistory(realTag)
+			} else {
+				g.logger.Debug("outbound ", tag, " available: ", t, "ms")
+				g.history.StoreURLTestHistory(realTag, &adapter.URLTestHistory{Time: time.Now(), Delay: t})
+				resultAccess.Lock()
+				result[tag] = t
+				resultAccess.Unlock()
+			}
+			return nil, nil
+		})
+	}
+	b.Wait()
+	g.performUpdateCheck()
+	return result, nil
+}
+
+func (g *FallbackGroup) performUpdateCheck() {
+	var updated bool
+	if outbound, exists := g.Select(N.NetworkTCP); outbound != nil && (g.selectedOutboundTCP == nil || (exists && outbound != g.selectedOutboundTCP)) {
+		if g.selectedOutboundTCP != nil {
+			updated = true
+		}
+		g.selectedOutboundTCP = outbound
+	}
+	if outbound, exists := g.Select(N.NetworkUDP); outbound != nil && (g.selectedOutboundUDP == nil || (exists && outbound != g.selectedOutboundUDP)) {
+		if g.selectedOutboundUDP != nil {
+			updated = true
+		}
+		g.selectedOutboundUDP = outbound
+	}
+	if updated {
+		g.interruptGroup.Interrupt(g.interruptExternalConnections)
+	}
+}


### PR DESCRIPTION
## Summary
- add `fallback` outbound type for automatic failover
- register fallback outbound and document usage

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_b_684b9ee2e8488327b63f803fe154c754